### PR TITLE
ci: improve main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,38 +1,59 @@
-name: Node.js workflow
+name: Node.js CI
 on:
   push:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-
   workflow_dispatch:
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, latest]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
       - name: Install
-        run: npm install
+        run: npm ci
       - name: Unit tests and lint
         run: npm run test:all
       - name: Build
         run: npm run build:all
+
+  post-build:
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    needs: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
       - name: Deploy documentation
         run: |
           git remote set-url origin https://git:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
           npm run deploy -- -u "github-actions-bot <support+actions@github.com>"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        if: ${{ github.event_name == 'push' }}
       - name: Upload code coverage
         uses: codecov/codecov-action@v3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+
+  success:
+    runs-on: ubuntu-latest
+    if: ${{ success() }}
+    needs:
+      - build
+      - post-build
+    steps:
+      - name: ✅ CI succeeded
+        run: exit 0


### PR DESCRIPTION
 - simplify CI workflow name
 - add build matrix for Node 18.x and latest
 - separate steps into different jobs, add success job if everything goes smoothly
 - replace `npm install` with dedicated `npm ci` (see: https://docs.npmjs.com/cli/v9/commands/npm-ci)
 - only run steps for deploying docs + uploading code coverage if it ran on push event